### PR TITLE
completed first 3 test cases of our project tests

### DIFF
--- a/orbital.AppHost/Program.cs
+++ b/orbital.AppHost/Program.cs
@@ -17,7 +17,7 @@ var container = database.AddContainer("meetings", "/type", "meetings");
 var orbital_api = builder.AddProject<orbital_api>("orbital-api")
         .WithReference(cosmosdb);
 
-builder.AddProject<orbital_web>("web")
+builder.AddProject<orbital_web>("orbital-web")
         .WithReference(orbital_api);
 
 builder.Build().Run();

--- a/orbital.api/Program.cs
+++ b/orbital.api/Program.cs
@@ -65,7 +65,7 @@ app.MapGet("/api/meetings", async (CosmosClient client) =>
     return Results.Ok(meetings);
 });
 
-app.MapGet("api/meetings/{id}", async (CosmosClient client, string id) =>
+app.MapGet("/api/meetings/{id}", async (CosmosClient client, string id) =>
 {
     try
     {

--- a/orbital.sln
+++ b/orbital.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "orbital.api", "orbital.api\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "orbital.core", "orbital.core\orbital.core.csproj", "{2DB798D1-240C-4FB1-A477-99B7706F1ED7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "orbital.test", "orbital.test\orbital.test.csproj", "{37097BC5-F6D3-43C1-B20B-4E5D9CEC783A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +50,10 @@ Global
 		{2DB798D1-240C-4FB1-A477-99B7706F1ED7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2DB798D1-240C-4FB1-A477-99B7706F1ED7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2DB798D1-240C-4FB1-A477-99B7706F1ED7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37097BC5-F6D3-43C1-B20B-4E5D9CEC783A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37097BC5-F6D3-43C1-B20B-4E5D9CEC783A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37097BC5-F6D3-43C1-B20B-4E5D9CEC783A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37097BC5-F6D3-43C1-B20B-4E5D9CEC783A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/orbital.test/ApiResourceIntegrationTest.cs
+++ b/orbital.test/ApiResourceIntegrationTest.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+
+namespace orbital.test
+{
+    public class ApiResourceIntegrationTest
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+        // Use NUnit's [TestCase] attribute for generic input pattern
+        [TestCase("/", HttpStatusCode.NotFound, TestName = "GetApiResourceRootReturnsNotFoundStatusCode")]
+        [TestCase("/api/Meetings", HttpStatusCode.OK, TestName = "GetApiMeetingsListReturnsOkStatusCode")]
+        [TestCase("/api/Meetings/3", HttpStatusCode.OK, TestName = "GetApiMeetingsItemReturnsOkStatusCode")]
+        public async Task GetApiEndpointReturnsExpectedStatusCode(string route, HttpStatusCode expectedStatusCode)
+        {
+            // Arrange
+            var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.orbital_AppHost>();
+            appHost.Services.AddLogging(logging =>
+            {
+                logging.SetMinimumLevel(LogLevel.Debug);
+                logging.AddFilter(appHost.Environment.ApplicationName, LogLevel.Debug);
+                logging.AddFilter("Aspire.", LogLevel.Debug);
+            });
+            appHost.Services.ConfigureHttpClientDefaults(clientBuilder =>
+            {
+                clientBuilder.AddStandardResilienceHandler();
+            });
+
+            await using var app = await appHost.BuildAsync().WaitAsync(DefaultTimeout);
+            await app.StartAsync().WaitAsync(DefaultTimeout);
+
+            // Act
+            var httpClient = app.CreateHttpClient("orbital-api");
+            await app.ResourceNotifications.WaitForResourceHealthyAsync("orbital-api").WaitAsync(DefaultTimeout);
+            var response = await httpClient.GetAsync(route);
+
+            // Assert
+            Assert.That(response.StatusCode, Is.EqualTo(expectedStatusCode));
+        }
+    }
+}

--- a/orbital.test/ApiResourceIntegrationTest.cs
+++ b/orbital.test/ApiResourceIntegrationTest.cs
@@ -8,8 +8,8 @@ namespace orbital.test
 
         // Use NUnit's [TestCase] attribute for generic input pattern
         [TestCase("/", HttpStatusCode.NotFound, TestName = "GetApiResourceRootReturnsNotFoundStatusCode")]
-        [TestCase("/api/Meetings", HttpStatusCode.OK, TestName = "GetApiMeetingsListReturnsOkStatusCode")]
-        [TestCase("/api/Meetings/3", HttpStatusCode.OK, TestName = "GetApiMeetingsItemReturnsOkStatusCode")]
+        [TestCase("/api/meetings", HttpStatusCode.OK, TestName = "GetApiMeetingsListReturnsOkStatusCode")]
+        [TestCase("/api/meetings/3", HttpStatusCode.OK, TestName = "GetApiMeetingsItemReturnsOkStatusCode")]
         public async Task GetApiEndpointReturnsExpectedStatusCode(string route, HttpStatusCode expectedStatusCode)
         {
             // Arrange

--- a/orbital.test/orbital.test.csproj
+++ b/orbital.test/orbital.test.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Testing" Version="9.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Net" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Aspire.Hosting.ApplicationModel" />
+    <Using Include="Aspire.Hosting.Testing" />
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="../orbital.AppHost/orbital.AppHost.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull request introduces several changes to the `orbital` project, focusing on improving naming consistency, enhancing API routing, adding a new test project, and updating the solution configuration. Below are the most important changes grouped by theme:

### Naming and Routing Improvements:
* Renamed the `orbital_web` project to `orbital-web` in `orbital.AppHost/Program.cs` for consistency with other project naming conventions.
* Updated the API route in `orbital.api/Program.cs` to include a leading slash (`/api/meetings/{id}`) for uniformity with RESTful API standards.

### Test Project Addition:
* Added a new test project `orbital.test` to the solution, including its configuration in `orbital.sln`. [[1]](diffhunk://#diff-fcc55d7d266407ab84cf6598e459041bdef664a42fd50774e7907e8769225696R25-R26) [[2]](diffhunk://#diff-fcc55d7d266407ab84cf6598e459041bdef664a42fd50774e7907e8769225696R53-R56)
* Implemented an integration test class `ApiResourceIntegrationTest` in `orbital.test/ApiResourceIntegrationTest.cs`, with NUnit test cases to validate API endpoints' status codes.
* Created the `orbital.test.csproj` file, setting it up as a .NET 9.0 test project with dependencies on NUnit, Aspire Hosting Testing, and other testing libraries.