### PR TITLE
In memory repository, UI update to allow time entry

### DIFF
--- a/orbital.api/Program.cs
+++ b/orbital.api/Program.cs
@@ -51,25 +51,18 @@ app.UseCors("LocalhostPolicy");
 
 app.UseHttpsRedirection();
 
+app.MapGet("api/hello", () => "Hello World!");
+
 app.MapGet("/api/meetings", async (IMeetingRepository repository) =>
 {
     var meetings = await repository.GetMeetingsAsync();
     return Results.Ok(meetings);
 });
 
-app.MapGet("/api/meetings/{id}", async (CosmosClient client, string id) =>
+app.MapGet("/api/meetings/{id}", async (string id, IMeetingRepository repository) =>
 {
-    try
-    {
-        var container = client.GetContainer("orbital", "meetings");
-        var response = await container.ReadItemAsync<Meeting>(id, new PartitionKey("meeting"));
-        return Results.Ok(response.Resource);
-    }
-    catch (CosmosException ex)
-    {
-        return Results.NotFound(ex.Message);
-    }
-
+    var meeting = await repository.GetMeetingByIdAsync(id);
+    return meeting;
 });
 
 app.MapPost("/api/meetings", async (CosmosClient client, Meeting meeting) =>
@@ -77,7 +70,7 @@ app.MapPost("/api/meetings", async (CosmosClient client, Meeting meeting) =>
     try
     {
         var container = client.GetContainer("orbital", "meetings");
-        var response = await container.CreateItemAsync(meeting, new PartitionKey(meeting.Type));
+        var response = await container.CreateItemAsync(meeting, new PartitionKey(Meeting.Type));
         return Results.Created($"/api/meetings/{meeting.Id}", meeting);
     }
     catch (Exception ex)

--- a/orbital.core/Data/IMeetingRepository.cs
+++ b/orbital.core/Data/IMeetingRepository.cs
@@ -5,5 +5,7 @@ namespace orbital.core.Data
     public interface IMeetingRepository
     {
         Task<IEnumerable<Meeting>> GetMeetingsAsync();
+
+        Task<Meeting> GetMeetingByIdAsync(string id);
     }
 }

--- a/orbital.core/Meeting.cs
+++ b/orbital.core/Meeting.cs
@@ -6,7 +6,7 @@ public class Meeting
 {
     public string Id { get; set; }
 
-    public string Type => "meeting";
+    public static string Type => "meeting";
 
     [Required(ErrorMessage = "Title is required")]
     [StringLength(100, ErrorMessage = "Title cannot exceed 100 characters")]

--- a/orbital.data/CosmosMeetingRepository.cs
+++ b/orbital.data/CosmosMeetingRepository.cs
@@ -15,6 +15,11 @@ namespace orbital.data
             _container = _client.GetContainer("orbital", "meetings");
         }
 
+        public Task<Meeting> GetMeetingByIdAsync(string id)
+        {
+            throw new NotImplementedException();
+        }
+
         public async Task<IEnumerable<Meeting>> GetMeetingsAsync()
         {
             var resultIterator = _container.GetItemQueryIterator<Meeting>("SELECT * FROM c WHERE c.type='meeting'");

--- a/orbital.test.api/ApiUnitTests.cs
+++ b/orbital.test.api/ApiUnitTests.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
+using orbital.core;
+using orbital.core.Data;
 using System.Net;
 
 namespace orbital.test.api
@@ -9,16 +11,61 @@ namespace orbital.test.api
 
         public ApiUnitTests(WebApplicationFactory<Program> factory)
         {
-            _factory = factory;
+            _factory = factory.WithWebHostBuilder(builder =>
+            {
+                // Configure the test environment, e.g., use an in-memory database or mock services
+                builder.ConfigureServices(services =>
+                {
+                    // Remove the real Cosmos DB repository to avoid external dependencies during tests
+                    var descriptor = services.SingleOrDefault(
+                        d => d.ServiceType == typeof(IMeetingRepository));
+
+                    if (descriptor != null)
+                    {
+                        services.Remove(descriptor);
+                    }
+
+                    // Replace the real repository with an in-memory one for testing
+                    services.AddScoped<IMeetingRepository, InMemoryMeetingRepository>();
+                });
+            });
+        }
+
+        [Theory]
+        [InlineData("/api/meetings", HttpStatusCode.OK)]
+        [InlineData("/api/meetings/1", HttpStatusCode.OK)]
+        public async Task GetMeetings_ReturnsOk(string targetUri, System.Net.HttpStatusCode code)
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+            // Act
+            var response = await client.GetAsync(targetUri);
+            // Assert
+            Assert.Equal(code, response.StatusCode);
         }
 
         [Fact]
-        public async Task GetMeetings_ReturnsOk()
+        public async Task GetMeetings_ReturnsCorrectAmount()
         {
             // Arrange
             var client = _factory.CreateClient();
             // Act
             var response = await client.GetAsync("/api/meetings");
+            response.EnsureSuccessStatusCode();
+
+            var meetings = await response.Content.ReadFromJsonAsync<IEnumerable<Meeting>>();
+            
+            // Assert
+            Assert.Equal(2, meetings.Count());
+        }
+
+        [Fact]
+        public async Task Hello_ReturnsOk()
+        {
+            // Arrange
+            var client = _factory.CreateClient();
+            // Act
+            var response = await client.GetAsync("/api/hello");
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }

--- a/orbital.test.api/InMemoryMeetingRepository.cs
+++ b/orbital.test.api/InMemoryMeetingRepository.cs
@@ -1,0 +1,29 @@
+﻿using orbital.core;
+using orbital.core.Data;
+
+namespace orbital.test.api
+{
+    public class InMemoryMeetingRepository : IMeetingRepository
+    {
+        private readonly List<Meeting> _meetings;
+
+        public InMemoryMeetingRepository()
+        {
+            _meetings = new List<Meeting>
+            {
+                new Meeting { Id = "1", Title = "Test Meeting 1", Description = "This is a test meeting." },
+                new Meeting { Id = "2", Title = "Test Meeting 2", Description = "This is another test meeting." }
+            };
+        }
+
+        public Task<Meeting> GetMeetingByIdAsync(string id)
+        {
+            return Task.FromResult(_meetings.First(m => m.Id == id));
+        }
+
+        public Task<IEnumerable<Meeting>> GetMeetingsAsync()
+        {
+            return Task.FromResult<IEnumerable<Meeting>>(_meetings);
+        }
+    }
+}

--- a/orbital.web/Pages/Meetings.razor
+++ b/orbital.web/Pages/Meetings.razor
@@ -35,12 +35,12 @@
                 <div class="row mb-3">
                     <div class="col">
                         <label for="startTime" class="form-label">Start Time</label>
-                        <InputDate id="startTime" @bind-Value="newMeeting.StartTime" class="form-control" />
+                        <InputDate id="startTime" Type="InputDateType.DateTimeLocal" @bind-Value="newMeeting.StartTime" class="form-control" />
                         <ValidationMessage For="@(() => newMeeting.StartTime)" />
                     </div>
                     <div class="col">
                         <label for="endTime" class="form-label">End Time</label>
-                        <InputDate id="endTime" @bind-Value="newMeeting.EndTime" class="form-control" />
+                        <InputDate id="endTime" Type="InputDateType.DateTimeLocal" @bind-Value="newMeeting.EndTime" class="form-control" />
                         <ValidationMessage For="@(() => newMeeting.EndTime)" />
                     </div>
                 </div>


### PR DESCRIPTION
This pull request introduces several changes to improve the API functionality, enhance testability, and fix minor issues in the UI. The most significant updates include refactoring the API to use a repository pattern, adding unit tests with an in-memory implementation, and updating the `Meeting` model. Below is a categorized summary of the most important changes:

### API Enhancements:
* Added a new `GET /api/hello` endpoint that returns a "Hello World!" response. (`orbital.api/Program.cs`, [orbital.api/Program.csR54-R73](diffhunk://#diff-0b28cf4b5e4f357659b5784e0c3154db5b5a0a22ed58a398936b74828001f61cR54-R73))
* Refactored `/api/meetings/{id}` to use the `IMeetingRepository` for fetching a meeting by ID instead of directly interacting with the Cosmos DB client. (`orbital.api/Program.cs`, [orbital.api/Program.csR54-R73](diffhunk://#diff-0b28cf4b5e4f357659b5784e0c3154db5b5a0a22ed58a398936b74828001f61cR54-R73))

### Repository Pattern:
* Updated the `IMeetingRepository` interface to include a new `GetMeetingByIdAsync` method. (`orbital.core/Data/IMeetingRepository.cs`, [orbital.core/Data/IMeetingRepository.csR8-R9](diffhunk://#diff-eb71c9fd82d06c5613df364ca44ac8eb2ffdfc5151944199b38608f39a2a6554R8-R9))
* Added a placeholder implementation of `GetMeetingByIdAsync` in `CosmosMeetingRepository`. (`orbital.data/CosmosMeetingRepository.cs`, [orbital.data/CosmosMeetingRepository.csR18-R22](diffhunk://#diff-b52ec2a34e59ac07e3b027dfdb349eaf4ccf71f4125b0377bdaa7f6edea55967R18-R22))

### Model Updates:
* Changed the `Type` property in the `Meeting` model to be `static`, as it represents a constant value for all meetings. (`orbital.core/Meeting.cs`, [orbital.core/Meeting.csL9-R9](diffhunk://#diff-9973495b7dd693bc670d987cab3beef779e9e25e8e8502cdaab548add9f6b16fL9-R9))

### Test Improvements:
* Configured the test environment to use an in-memory repository (`InMemoryMeetingRepository`) instead of the real Cosmos DB repository, ensuring tests are independent of external dependencies. (`orbital.test.api/ApiUnitTests.cs`, [orbital.test.api/ApiUnitTests.csL12-R68](diffhunk://#diff-72f6b94df6f8688c8c959460b7ecf56827207e3885bb69b90a4a2242647aabddL12-R68))
* Added unit tests for the `/api/meetings` and `/api/hello` endpoints, verifying their responses and behavior. (`orbital.test.api/ApiUnitTests.cs`, [orbital.test.api/ApiUnitTests.csL12-R68](diffhunk://#diff-72f6b94df6f8688c8c959460b7ecf56827207e3885bb69b90a4a2242647aabddL12-R68))
* Implemented `InMemoryMeetingRepository` for testing purposes, providing mock data for meetings. (`orbital.test.api/InMemoryMeetingRepository.cs`, [orbital.test.api/InMemoryMeetingRepository.csR1-R29](diffhunk://#diff-c9110f1b51e153160b069f759147caf3893cc17922b30af1b4fe88466371b7edR1-R29))

### UI Fix:
* Updated the `InputDate` components in the `Meetings.razor` page to use `InputDateType.DateTimeLocal`, enabling better handling of date and time inputs. (`orbital.web/Pages/Meetings.razor`, [orbital.web/Pages/Meetings.razorL38-R43](diffhunk://#diff-c8ec8eacc2a0f323152990b5a5e79c4834fcd6c446bf0b9518f2975424e50800L38-R43))