### PR TITLE
API returns 404 NotFound when meeting id not found

### DIFF
--- a/orbital.api/Program.cs
+++ b/orbital.api/Program.cs
@@ -60,7 +60,13 @@ app.MapGet("/api/meetings", async (IMeetingRepository repository) =>
 app.MapGet("/api/meetings/{id}", async (string id, IMeetingRepository repository) =>
 {
     var meeting = await repository.GetMeetingByIdAsync(id);
-    return meeting;
+    
+    if (meeting == null)
+    {
+        return Results.NotFound();
+    }
+
+    return Results.Ok(meeting);
 });
 
 app.MapPost("/api/meetings", async (Meeting meeting, IMeetingRepository repository) =>


### PR DESCRIPTION
Previously was returning a null response body and 200 Success.

Resolving issue #28 