### PR TITLE
update to .NET aspire 9.3.1

### DIFF
--- a/orbital.AppHost/orbital.AppHost.csproj
+++ b/orbital.AppHost/orbital.AppHost.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="9.2.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="9.3.1" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/orbital.api/orbital.api.csproj
+++ b/orbital.api/orbital.api.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="9.2.0" />
+		<PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="9.3.1" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
 	</ItemGroup>
 


### PR DESCRIPTION
This pull request updates package dependencies in the `orbital.AppHost` and `orbital.api` projects to newer versions. The changes ensure compatibility with the latest features and bug fixes provided by the updated packages.

Dependency updates:

* [`orbital.AppHost/orbital.AppHost.csproj`](diffhunk://#diff-949b61d4d591bf87102c0f08d2e5223f6a52b7f4297478f15aea822aec55a3cdL14-R15): Updated `Aspire.Hosting.AppHost` and `Aspire.Hosting.Azure.CosmosDB` package references from version `9.2.0` to `9.3.1`.
* [`orbital.api/orbital.api.csproj`](diffhunk://#diff-44999059cd38ac04e998ebf3ca965c72c341f6b770d4e4106dad919c183a1771L14-R14): Updated `Aspire.Microsoft.Azure.Cosmos` package reference from version `9.2.0` to `9.3.1`.