### PR TITLE
Bump Aspire.AppHost.Sdk to 9.3.1

### DIFF
--- a/orbital.AppHost/orbital.AppHost.csproj
+++ b/orbital.AppHost/orbital.AppHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.1" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -21,3 +21,4 @@
 	</ItemGroup>
 
 </Project>
+ 


### PR DESCRIPTION
Forgot to bump the Aspire SDK version number when upgrading the packages to 9.3.1